### PR TITLE
Improve password setup UX

### DIFF
--- a/app.py
+++ b/app.py
@@ -599,6 +599,7 @@ def create_user():
         name = request.form.get('name', '').strip()
         email = request.form.get('email', '').strip()
         password = request.form.get('password', '')
+        confirm = request.form.get('confirm_password', '')
         is_admin = int('is_admin' in request.form)
 
         if not name:
@@ -607,6 +608,10 @@ def create_user():
             errors['email'] = "正しいメールアドレスを入力してください。"
         if not password or len(password) < 8:
             errors['password'] = "パスワードは8文字以上で入力してください。"
+        if not confirm:
+            errors['confirm_password'] = "パスワード（確認）を入力してください。"
+        elif password and password != confirm:
+            errors['confirm_password'] = "パスワードが一致しません。"
 
         if errors:
             return render_template('create_user.html', errors=errors)
@@ -736,6 +741,7 @@ def setup():
         name = request.form['name']
         email = request.form['email']
         password = request.form['password']
+        confirm = request.form.get('confirm_password', '')
         errors = []
         if not name:
             errors.append("氏名を入力してください。")
@@ -743,6 +749,10 @@ def setup():
             errors.append("正しいメールアドレスを入力してください。")
         if not password or len(password) < 8:
             errors.append("パスワードは8文字以上で入力してください。")
+        if not confirm:
+            errors.append("パスワード（確認）を入力してください。")
+        elif password != confirm:
+            errors.append("パスワードが一致しません。")
         if errors:
             for msg in errors:
                 flash(msg, "danger")

--- a/templates/create_user.html
+++ b/templates/create_user.html
@@ -42,6 +42,20 @@
       <div class="invalid-feedback d-block">{{ errors.get('password') }}</div>
     {% endif %}
   </div>
+  <div class="mb-3">
+    <label class="form-label">パスワード（確認）</label>
+    <div class="input-group">
+      <input type="password" name="confirm_password"
+        class="form-control {% if errors and errors.get('confirm_password') %}is-invalid{% endif %}"
+        id="createPasswordConfirm"
+        required>
+      <button type="button" class="btn btn-outline-secondary" tabindex="-1"
+        onclick="togglePwd('createPasswordConfirm', this)">👁</button>
+    </div>
+    {% if errors and errors.get('confirm_password') %}
+      <div class="invalid-feedback d-block">{{ errors.get('confirm_password') }}</div>
+    {% endif %}
+  </div>
 
   <div class="form-check mb-3">
     <input class="form-check-input" type="checkbox" name="is_admin" id="adminCheck"

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <h2>初期管理者アカウントの作成</h2>
-<form method="POST">
+<form method="POST" autocomplete="off">
   <!-- CSRFトークン追加 -->
   <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
@@ -17,8 +17,35 @@
   </div>
   <div class="mb-3">
     <label class="form-label">パスワード</label>
-    <input type="password" class="form-control" name="password" required>
+    <div class="input-group">
+      <input type="password" class="form-control" name="password"
+        id="setupPassword" required>
+      <button type="button" class="btn btn-outline-secondary" tabindex="-1"
+        onclick="togglePwd('setupPassword', this)">👁</button>
+    </div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">パスワード（確認）</label>
+    <div class="input-group">
+      <input type="password" class="form-control" name="confirm_password"
+        id="setupPasswordConfirm" required>
+      <button type="button" class="btn btn-outline-secondary" tabindex="-1"
+        onclick="togglePwd('setupPasswordConfirm', this)">👁</button>
+    </div>
   </div>
   <button type="submit" class="btn btn-success">作成</button>
 </form>
+
+<script>
+function togglePwd(id, btn) {
+  const field = document.getElementById(id);
+  if (field.type === "password") {
+    field.type = "text";
+    btn.innerText = "🙈";
+  } else {
+    field.type = "password";
+    btn.innerText = "👁";
+  }
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- require password confirmation when creating the first admin and when admins create users
- add show/hide password toggles on the setup screen
- update HTML forms to include confirmation fields

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427c143c74832a93723f7a57094836