### PR TITLE
Fix user deletion flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -557,16 +557,22 @@ def export_combined():
             os.makedirs(export_subdir, exist_ok=True)
             csv_path = generate_csv(user_id, name, year, month, export_subdir, get_overtime_threshold(user_id))
             if not csv_path:
-                return '該当データがありません'
+                flash('該当データがありません。', 'warning')
+                return redirect(url_for('export_combined'))
             return send_file(csv_path, mimetype='text/csv', as_attachment=True, download_name=os.path.basename(csv_path))
         elif request.form['action'] == 'bulk_all':
             with tempfile.TemporaryDirectory() as temp_dir:
                 zip_path = os.path.join(temp_dir, f"勤怠記録_{year}_{month:02d}.zip")
+                any_file = False
                 with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
                     for user_id, name in user_list:
                         csv_file = generate_csv(user_id, name, year, month, temp_dir, get_overtime_threshold(user_id))
                         if csv_file:
                             zipf.write(csv_file, os.path.basename(csv_file))
+                            any_file = True
+                if not any_file:
+                    flash('該当データがありません。', 'warning')
+                    return redirect(url_for('export_combined'))
                 return send_file(zip_path, mimetype='application/zip', as_attachment=True, download_name=f"勤怠記録_{year}_{month:02d}.zip")
     return render_template('export.html', user_list=user_list, now=now, years=years)
 
@@ -599,6 +605,7 @@ def create_user():
         name = request.form.get('name', '').strip()
         email = request.form.get('email', '').strip()
         password = request.form.get('password', '')
+        confirm = request.form.get('confirm_password', '')
         is_admin = int('is_admin' in request.form)
 
         if not name:
@@ -607,6 +614,10 @@ def create_user():
             errors['email'] = "正しいメールアドレスを入力してください。"
         if not password or len(password) < 8:
             errors['password'] = "パスワードは8文字以上で入力してください。"
+        if not confirm:
+            errors['confirm_password'] = "パスワード（確認）を入力してください。"
+        elif password and password != confirm:
+            errors['confirm_password'] = "パスワードが一致しません。"
 
         if errors:
             return render_template('create_user.html', errors=errors)
@@ -642,6 +653,7 @@ def update_managed_users():
         c.execute("INSERT INTO admin_managed_users (admin_id, user_id) VALUES (?, ?)", (admin_id, user_id))
     conn.commit()
     conn.close()
+    flash("管理対象を更新しました。", "success")
     return redirect(url_for('list_users'))
 
 @app.route('/admin/users/edit/<int:user_id>', methods=['GET', 'POST'])
@@ -699,27 +711,38 @@ def edit_user(user_id):
     conn.close()
     return render_template('edit_user.html', user_id=user_id, user=user, errors=errors)
 
-@app.route('/admin/users/delete/<int:user_id>', methods=['POST'])
+@app.route('/admin/users/delete/<int:user_id>', methods=['GET', 'POST'])
 @admin_required
 def delete_user(user_id):
-    if not check_csrf():
-        return redirect(url_for('list_users'))
-    # 自分自身の削除は禁止
-    if user_id == session.get('user_id'):
-        flash("自分自身のアカウントは削除できません。", "danger")
-        return redirect(url_for('list_users'))
     conn = get_db()
     c = conn.cursor()
-    c.execute("SELECT is_superadmin FROM users WHERE id = ?", (user_id,))
-    row = c.fetchone()
-    if row and row["is_superadmin"]:
-        flash("スーパー管理者は削除できません。", "danger")
+    c.execute("SELECT id, name, is_superadmin FROM users WHERE id = ?", (user_id,))
+    user = c.fetchone()
+    if not user:
         conn.close()
+        flash("ユーザーが見つかりません。", "danger")
         return redirect(url_for('list_users'))
-    c.execute("DELETE FROM users WHERE id = ?", (user_id,))
-    conn.commit()
+
+    if request.method == 'POST':
+        if not check_csrf():
+            conn.close()
+            return redirect(url_for('list_users'))
+        if user_id == session.get('user_id'):
+            flash("自分自身のアカウントは削除できません。", "danger")
+            conn.close()
+            return redirect(url_for('list_users'))
+        if user['is_superadmin']:
+            flash("スーパー管理者は削除できません。", "danger")
+            conn.close()
+            return redirect(url_for('list_users'))
+        c.execute("DELETE FROM users WHERE id = ?", (user_id,))
+        conn.commit()
+        conn.close()
+        flash("ユーザーを削除しました。", "success")
+        return redirect(url_for('list_users'))
+
     conn.close()
-    return redirect(url_for('list_users'))
+    return render_template('confirm_delete_user.html', user=user)
 
 @app.route('/setup', methods=['GET', 'POST'])
 def setup():
@@ -736,6 +759,7 @@ def setup():
         name = request.form['name']
         email = request.form['email']
         password = request.form['password']
+        confirm = request.form.get('confirm_password', '')
         errors = []
         if not name:
             errors.append("氏名を入力してください。")
@@ -743,6 +767,10 @@ def setup():
             errors.append("正しいメールアドレスを入力してください。")
         if not password or len(password) < 8:
             errors.append("パスワードは8文字以上で入力してください。")
+        if not confirm:
+            errors.append("パスワード（確認）を入力してください。")
+        elif password != confirm:
+            errors.append("パスワードが一致しません。")
         if errors:
             for msg in errors:
                 flash(msg, "danger")

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -4,13 +4,11 @@
 {% block content %}
 <h2 class="mb-3">ユーザー一覧</h2>
 
-<form method="POST" action="{{ url_for('update_managed_users') }}">
-  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-  <div class="d-grid mb-3">
+<div class="d-grid mb-3">
     <a class="btn btn-success" href="{{ url_for('create_user') }}">＋ 新規ユーザー作成</a>
   </div>
 
-  <div class="table-responsive" style="max-width: fit-content; margin: 0 auto;">
+<div class="table-responsive" style="max-width: fit-content; margin: 0 auto;">
     <table class="table table-bordered align-middle text-nowrap" style="width: auto; min-width: 600px;">
       <thead class="table-light">
         <tr>
@@ -36,7 +34,7 @@
             {% endif %}
           </td>
           <td class="text-center">
-            <input type="checkbox" name="managed_users" value="{{ user["id_name"][0] }}"
+            <input type="checkbox" name="managed_users" form="manageForm" value="{{ user["id_name"][0] }}"
               {% if user["is_managed"] %}checked{% endif %}
               {% if user["id_name"][4] %}disabled{% endif %}>
           </td>
@@ -49,12 +47,7 @@
                 <span class="text-muted small d-block py-1" style="min-width:90px;">自分自身は削除できません</span>
               {% else %}
                 <a class="btn btn-sm btn-outline-primary mb-1" href="{{ url_for('edit_user', user_id=user["id_name"][0]) }}" style="min-width:90px;">編集</a>
-                <form method="POST" action="{{ url_for('delete_user', user_id=user['id_name'][0]) }}"
-                      onsubmit="return confirm('本当に削除しますか？');"
-                      class="m-0" style="min-width:90px;">
-                  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-                  <button class="btn btn-sm btn-outline-danger" type="submit" style="min-width:90px;">削除</button>
-                </form>
+                <a class="btn btn-sm btn-outline-danger" href="{{ url_for('delete_user', user_id=user['id_name'][0]) }}" style="min-width:90px;">削除</a>
               {% endif %}
             </div>
           </td>
@@ -64,7 +57,9 @@
     </table>
   </div>
 
-  <div class="d-grid mt-3">
+<form id="manageForm" method="POST" action="{{ url_for('update_managed_users') }}" class="mt-3">
+  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+  <div class="d-grid">
     <button type="submit" class="btn btn-success">管理対象を保存</button>
   </div>
 </form>

--- a/templates/confirm_delete_user.html
+++ b/templates/confirm_delete_user.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{% block title %}ユーザー削除確認{% endblock %}
+
+{% block content %}
+<h2 class="mb-3">ユーザー削除確認</h2>
+<p class="mb-4">{{ user.name }} を削除してよろしいですか？</p>
+<form method="POST">
+  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+  <div class="d-grid gap-2">
+    <button type="submit" class="btn btn-danger">削除</button>
+    <a href="{{ url_for('list_users') }}" class="btn btn-outline-secondary">キャンセル</a>
+  </div>
+</form>
+{% endblock %}

--- a/templates/create_user.html
+++ b/templates/create_user.html
@@ -42,6 +42,20 @@
       <div class="invalid-feedback d-block">{{ errors.get('password') }}</div>
     {% endif %}
   </div>
+  <div class="mb-3">
+    <label class="form-label">パスワード（確認）</label>
+    <div class="input-group">
+      <input type="password" name="confirm_password"
+        class="form-control {% if errors and errors.get('confirm_password') %}is-invalid{% endif %}"
+        id="createPasswordConfirm"
+        required>
+      <button type="button" class="btn btn-outline-secondary" tabindex="-1"
+        onclick="togglePwd('createPasswordConfirm', this)">👁</button>
+    </div>
+    {% if errors and errors.get('confirm_password') %}
+      <div class="invalid-feedback d-block">{{ errors.get('confirm_password') }}</div>
+    {% endif %}
+  </div>
 
   <div class="form-check mb-3">
     <input class="form-check-input" type="checkbox" name="is_admin" id="adminCheck"

--- a/templates/my_logs.html
+++ b/templates/my_logs.html
@@ -7,7 +7,7 @@
 <!-- ▼ CSVテンプレートダウンロードボタンを追加 -->
 <div class="mb-3">
   <a href="{{ url_for('static', filename='テンプレート.csv') }}"
-     class="btn btn-outline-secondary btn-sm">
+     class="btn btn-outline-secondary btn-sm" download>
     CSVテンプレートをダウンロード
   </a>
   <span class="ms-2 text-muted small">ヘッダー行は変更しないでください</span>

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <h2>初期管理者アカウントの作成</h2>
-<form method="POST">
+<form method="POST" autocomplete="off">
   <!-- CSRFトークン追加 -->
   <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
   <div class="mb-3">
@@ -17,8 +17,35 @@
   </div>
   <div class="mb-3">
     <label class="form-label">パスワード</label>
-    <input type="password" class="form-control" name="password" required>
+    <div class="input-group">
+      <input type="password" class="form-control" name="password"
+        id="setupPassword" required>
+      <button type="button" class="btn btn-outline-secondary" tabindex="-1"
+        onclick="togglePwd('setupPassword', this)">👁</button>
+    </div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">パスワード（確認）</label>
+    <div class="input-group">
+      <input type="password" class="form-control" name="confirm_password"
+        id="setupPasswordConfirm" required>
+      <button type="button" class="btn btn-outline-secondary" tabindex="-1"
+        onclick="togglePwd('setupPasswordConfirm', this)">👁</button>
+    </div>
   </div>
   <button type="submit" class="btn btn-success">作成</button>
 </form>
+
+<script>
+function togglePwd(id, btn) {
+  const field = document.getElementById(id);
+  if (field.type === "password") {
+    field.type = "text";
+    btn.innerText = "🙈";
+  } else {
+    field.type = "password";
+    btn.innerText = "👁";
+  }
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- avoid nested forms on user management page and link delete to confirmation
- add confirmation page before deleting a user
- handle deletion in route via GET+POST

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68427c143c74832a93723f7a57094836