### PR TITLE
Fix download path traversal

### DIFF
--- a/app.py
+++ b/app.py
@@ -284,12 +284,15 @@ def resolve_punch():
     referer = request.form.get('referer', url_for('index'))
     return redirect(referer)
 
-@app.route('/exports/<filename>')
+@app.route('/exports/<path:filename>')
 @admin_required
 def download_export_file(filename):
-    filepath = os.path.join(EXPORT_DIR, filename)
+    export_root = os.path.abspath(EXPORT_DIR)
+    filepath = os.path.abspath(os.path.join(EXPORT_DIR, filename))
+    if not filepath.startswith(export_root + os.sep):
+        return '不正なファイルパスです', 400
     if not os.path.isfile(filepath):
-        return 'ファイルが存在しません'
+        return 'ファイルが存在しません', 404
     return send_file(filepath, as_attachment=True, mimetype='text/csv')
 
 @app.route('/my/password', methods=['GET', 'POST'])

--- a/tests/test_export_security.py
+++ b/tests/test_export_security.py
@@ -1,0 +1,17 @@
+import os, sys
+import pytest
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess['is_admin'] = True
+        yield client
+
+def test_path_traversal_rejected(client):
+    resp = client.get('/exports/../app.py')
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- secure download_export_file by verifying absolute paths
- allow nested paths and reject traversal attempts
- add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428dadc0d0832ab9d6c0b9e7225a9a