### PR TITLE
Fix bare excepts in app

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,7 +154,7 @@ def generate_csv(user_id, name, year, month, target_dir, overtime_threshold='18:
                         delta = out_dt - th_dt
                         h, m = divmod(delta.seconds // 60, 60)
                         overtime = f"{h:02d}:{m:02d}"
-                except:
+                except ValueError:
                     pass
             writer.writerow([day, weekday, data['in'], data['out'], data['description'], overtime])
     return filepath
@@ -478,7 +478,7 @@ def view_my_logs():
                     delta = out_dt - th_dt
                     hours, minutes = divmod(delta.seconds // 60, 60)
                     data['overtime'] = f"{hours:02d}:{minutes:02d}"
-            except:
+            except ValueError:
                 data['overtime'] = ''
         else:
             data['overtime'] = ''


### PR DESCRIPTION
## Summary
- avoid hiding unexpected errors during time parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429789afa4832a808cd92fe4e33919