### PR TITLE
Add My Page screen with password change

### DIFF
--- a/app.py
+++ b/app.py
@@ -372,14 +372,15 @@ def download_export_file(filename):
         return 'ファイルが存在しません', 404
     return send_file(filepath, as_attachment=True, mimetype='text/csv')
 
+@app.route('/my', methods=['GET', 'POST'])
 @app.route('/my/password', methods=['GET', 'POST'])
 @login_required
-def change_password():
+def my_page():
     user_id = session['user_id']
     errors = {}
     if request.method == 'POST':
         if not check_csrf():
-            return redirect(url_for('change_password'))
+            return redirect(url_for('my_page'))
         current = request.form.get('current_password', '')
         new = request.form.get('new_password', '')
         confirm = request.form.get('confirm_password', '')
@@ -411,9 +412,9 @@ def change_password():
                 flash("パスワードを更新しました。", "success")
                 return redirect(url_for('index'))
 
-        return render_template('change_password.html', errors=errors)
+        return render_template('my_page.html', errors=errors)
 
-    return render_template('change_password.html', errors=errors)
+    return render_template('my_page.html', errors=errors)
 
 @app.route('/my/import', methods=['POST'])
 @login_required

--- a/app.py
+++ b/app.py
@@ -372,15 +372,19 @@ def download_export_file(filename):
         return 'ファイルが存在しません', 404
     return send_file(filepath, as_attachment=True, mimetype='text/csv')
 
-@app.route('/my', methods=['GET', 'POST'])
-@app.route('/my/password', methods=['GET', 'POST'])
+@app.route('/my')
 @login_required
 def my_page():
+    return render_template('my_page.html')
+
+@app.route('/my/password', methods=['GET', 'POST'])
+@login_required
+def my_password():
     user_id = session['user_id']
     errors = {}
     if request.method == 'POST':
         if not check_csrf():
-            return redirect(url_for('my_page'))
+            return redirect(url_for('my_password'))
         current = request.form.get('current_password', '')
         new = request.form.get('new_password', '')
         confirm = request.form.get('confirm_password', '')
@@ -412,9 +416,9 @@ def my_page():
                 flash("パスワードを更新しました。", "success")
                 return redirect(url_for('index'))
 
-        return render_template('my_page.html', errors=errors)
+        return render_template('my_password.html', errors=errors)
 
-    return render_template('my_page.html', errors=errors)
+    return render_template('my_password.html', errors=errors)
 
 @app.route('/my/import', methods=['POST'])
 @login_required

--- a/templates/base.html
+++ b/templates/base.html
@@ -40,7 +40,7 @@
         {% endif %}
         {% endif %}
         {% if session.get('user_id') %}
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('change_password') }}">パスワード変更</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('my_page') }}">マイページ</a></li>
         {% endif %}
       </ul>
       {% if session.get('user_id') %}

--- a/templates/my_page.html
+++ b/templates/my_page.html
@@ -2,6 +2,12 @@
 {% block title %}マイページ{% endblock %}
 
 {% block content %}
+<style>
+/* マイページは幅に余裕を持たせる */
+.container {
+  max-width: 900px;
+}
+</style>
 <h1 class="mb-4">マイページ</h1>
 
 <div class="row">

--- a/templates/my_page.html
+++ b/templates/my_page.html
@@ -4,62 +4,72 @@
 {% block content %}
 <h1 class="mb-4">マイページ</h1>
 
-<form method="POST" autocomplete="off">
-  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-
-  <div class="mb-3">
-    <label for="current_password" class="form-label">現在のパスワード</label>
-    <div class="input-group">
-      <input type="password"
-        id="current_password"
-        name="current_password"
-        class="form-control {% if errors and errors.get('current_password') %}is-invalid{% endif %}"
-        required>
-      <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
-        onclick="togglePwd('current_password', this)">👁</button>
+<div class="row">
+  <div class="col-md-3 mb-3">
+    <div class="list-group">
+      <a href="{{ url_for('my_page') }}" class="list-group-item list-group-item-action active">パスワード変更</a>
     </div>
-    {% if errors and errors.get('current_password') %}
-      <div class="invalid-feedback d-block">{{ errors.get('current_password') }}</div>
-    {% endif %}
   </div>
+  <div class="col-md-9">
+    <h2 class="h5 mb-3">パスワード変更</h2>
+    <form method="POST" autocomplete="off">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
 
-  <div class="mb-3">
-    <label for="new_password" class="form-label">新しいパスワード</label>
-    <div class="input-group">
-      <input type="password"
-        id="new_password"
-        name="new_password"
-        class="form-control {% if errors and errors.get('new_password') %}is-invalid{% endif %}"
-        required>
-      <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
-        onclick="togglePwd('new_password', this)">👁</button>
-    </div>
-    {% if errors and errors.get('new_password') %}
-      <div class="invalid-feedback d-block">{{ errors.get('new_password') }}</div>
-    {% endif %}
-  </div>
+      <div class="mb-3">
+        <label for="current_password" class="form-label">現在のパスワード</label>
+        <div class="input-group">
+          <input type="password"
+            id="current_password"
+            name="current_password"
+            class="form-control {% if errors and errors.get('current_password') %}is-invalid{% endif %}"
+            required>
+          <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
+            onclick="togglePwd('current_password', this)">👁</button>
+        </div>
+        {% if errors and errors.get('current_password') %}
+          <div class="invalid-feedback d-block">{{ errors.get('current_password') }}</div>
+        {% endif %}
+      </div>
 
-  <div class="mb-3">
-    <label for="confirm_password" class="form-label">新しいパスワード（確認）</label>
-    <div class="input-group">
-      <input type="password"
-        id="confirm_password"
-        name="confirm_password"
-        class="form-control {% if errors and errors.get('confirm_password') %}is-invalid{% endif %}"
-        required>
-      <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
-        onclick="togglePwd('confirm_password', this)">👁</button>
-    </div>
-    {% if errors and errors.get('confirm_password') %}
-      <div class="invalid-feedback d-block">{{ errors.get('confirm_password') }}</div>
-    {% endif %}
-  </div>
+      <div class="mb-3">
+        <label for="new_password" class="form-label">新しいパスワード</label>
+        <div class="input-group">
+          <input type="password"
+            id="new_password"
+            name="new_password"
+            class="form-control {% if errors and errors.get('new_password') %}is-invalid{% endif %}"
+            required>
+          <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
+            onclick="togglePwd('new_password', this)">👁</button>
+        </div>
+        {% if errors and errors.get('new_password') %}
+          <div class="invalid-feedback d-block">{{ errors.get('new_password') }}</div>
+        {% endif %}
+      </div>
 
-  <div class="d-grid gap-2">
-    <button type="submit" class="btn btn-primary">変更する</button>
-    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">戻る</a>
+      <div class="mb-3">
+        <label for="confirm_password" class="form-label">新しいパスワード（確認）</label>
+        <div class="input-group">
+          <input type="password"
+            id="confirm_password"
+            name="confirm_password"
+            class="form-control {% if errors and errors.get('confirm_password') %}is-invalid{% endif %}"
+            required>
+          <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
+            onclick="togglePwd('confirm_password', this)">👁</button>
+        </div>
+        {% if errors and errors.get('confirm_password') %}
+          <div class="invalid-feedback d-block">{{ errors.get('confirm_password') }}</div>
+        {% endif %}
+      </div>
+
+      <div class="d-grid gap-2">
+        <button type="submit" class="btn btn-primary">変更する</button>
+        <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">戻る</a>
+      </div>
+    </form>
   </div>
-</form>
+</div>
 
 <script>
 function togglePwd(id, btn) {

--- a/templates/my_page.html
+++ b/templates/my_page.html
@@ -13,80 +13,12 @@
 <div class="row">
   <div class="col-md-3 mb-3">
     <div class="list-group">
-      <a href="{{ url_for('my_page') }}" class="list-group-item list-group-item-action active">パスワード変更</a>
+      <a href="{{ url_for('my_page') }}" class="list-group-item list-group-item-action active">プロフィール</a>
+      <a href="{{ url_for('my_password') }}" class="list-group-item list-group-item-action">パスワード変更</a>
     </div>
   </div>
   <div class="col-md-9">
-    <h2 class="h5 mb-3">パスワード変更</h2>
-    <form method="POST" autocomplete="off">
-      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-
-      <div class="mb-3">
-        <label for="current_password" class="form-label">現在のパスワード</label>
-        <div class="input-group">
-          <input type="password"
-            id="current_password"
-            name="current_password"
-            class="form-control {% if errors and errors.get('current_password') %}is-invalid{% endif %}"
-            required>
-          <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
-            onclick="togglePwd('current_password', this)">👁</button>
-        </div>
-        {% if errors and errors.get('current_password') %}
-          <div class="invalid-feedback d-block">{{ errors.get('current_password') }}</div>
-        {% endif %}
-      </div>
-
-      <div class="mb-3">
-        <label for="new_password" class="form-label">新しいパスワード</label>
-        <div class="input-group">
-          <input type="password"
-            id="new_password"
-            name="new_password"
-            class="form-control {% if errors and errors.get('new_password') %}is-invalid{% endif %}"
-            required>
-          <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
-            onclick="togglePwd('new_password', this)">👁</button>
-        </div>
-        {% if errors and errors.get('new_password') %}
-          <div class="invalid-feedback d-block">{{ errors.get('new_password') }}</div>
-        {% endif %}
-      </div>
-
-      <div class="mb-3">
-        <label for="confirm_password" class="form-label">新しいパスワード（確認）</label>
-        <div class="input-group">
-          <input type="password"
-            id="confirm_password"
-            name="confirm_password"
-            class="form-control {% if errors and errors.get('confirm_password') %}is-invalid{% endif %}"
-            required>
-          <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
-            onclick="togglePwd('confirm_password', this)">👁</button>
-        </div>
-        {% if errors and errors.get('confirm_password') %}
-          <div class="invalid-feedback d-block">{{ errors.get('confirm_password') }}</div>
-        {% endif %}
-      </div>
-
-      <div class="d-grid gap-2">
-        <button type="submit" class="btn btn-primary">変更する</button>
-        <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">戻る</a>
-      </div>
-    </form>
+    <p>こんにちは、{{ session.get('user_name') }}さん</p>
   </div>
 </div>
-
-<script>
-function togglePwd(id, btn) {
-  const field = document.getElementById(id);
-  if (field.type === "password") {
-    field.type = "text";
-    btn.innerText = "🙈";
-  } else {
-    field.type = "password";
-    btn.innerText = "👁";
-  }
-}
-</script>
 {% endblock %}

--- a/templates/my_page.html
+++ b/templates/my_page.html
@@ -1,0 +1,76 @@
+{% extends 'base.html' %}
+{% block title %}マイページ{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">マイページ</h1>
+
+<form method="POST" autocomplete="off">
+  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+
+  <div class="mb-3">
+    <label for="current_password" class="form-label">現在のパスワード</label>
+    <div class="input-group">
+      <input type="password"
+        id="current_password"
+        name="current_password"
+        class="form-control {% if errors and errors.get('current_password') %}is-invalid{% endif %}"
+        required>
+      <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
+        onclick="togglePwd('current_password', this)">👁</button>
+    </div>
+    {% if errors and errors.get('current_password') %}
+      <div class="invalid-feedback d-block">{{ errors.get('current_password') }}</div>
+    {% endif %}
+  </div>
+
+  <div class="mb-3">
+    <label for="new_password" class="form-label">新しいパスワード</label>
+    <div class="input-group">
+      <input type="password"
+        id="new_password"
+        name="new_password"
+        class="form-control {% if errors and errors.get('new_password') %}is-invalid{% endif %}"
+        required>
+      <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
+        onclick="togglePwd('new_password', this)">👁</button>
+    </div>
+    {% if errors and errors.get('new_password') %}
+      <div class="invalid-feedback d-block">{{ errors.get('new_password') }}</div>
+    {% endif %}
+  </div>
+
+  <div class="mb-3">
+    <label for="confirm_password" class="form-label">新しいパスワード（確認）</label>
+    <div class="input-group">
+      <input type="password"
+        id="confirm_password"
+        name="confirm_password"
+        class="form-control {% if errors and errors.get('confirm_password') %}is-invalid{% endif %}"
+        required>
+      <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
+        onclick="togglePwd('confirm_password', this)">👁</button>
+    </div>
+    {% if errors and errors.get('confirm_password') %}
+      <div class="invalid-feedback d-block">{{ errors.get('confirm_password') }}</div>
+    {% endif %}
+  </div>
+
+  <div class="d-grid gap-2">
+    <button type="submit" class="btn btn-primary">変更する</button>
+    <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">戻る</a>
+  </div>
+</form>
+
+<script>
+function togglePwd(id, btn) {
+  const field = document.getElementById(id);
+  if (field.type === "password") {
+    field.type = "text";
+    btn.innerText = "🙈";
+  } else {
+    field.type = "password";
+    btn.innerText = "👁";
+  }
+}
+</script>
+{% endblock %}

--- a/templates/my_password.html
+++ b/templates/my_password.html
@@ -1,0 +1,93 @@
+{% extends 'base.html' %}
+{% block title %}マイページ{% endblock %}
+
+{% block content %}
+<style>
+/* マイページは幅に余裕を持たせる */
+.container {
+  max-width: 900px;
+}
+</style>
+<h1 class="mb-4">マイページ</h1>
+
+<div class="row">
+  <div class="col-md-3 mb-3">
+    <div class="list-group">
+      <a href="{{ url_for('my_page') }}" class="list-group-item list-group-item-action">プロフィール</a>
+      <a href="{{ url_for('my_password') }}" class="list-group-item list-group-item-action active">パスワード変更</a>
+    </div>
+  </div>
+  <div class="col-md-9">
+    <h2 class="h5 mb-3">パスワード変更</h2>
+    <form method="POST" autocomplete="off">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+
+      <div class="mb-3">
+        <label for="current_password" class="form-label">現在のパスワード</label>
+        <div class="input-group">
+          <input type="password"
+            id="current_password"
+            name="current_password"
+            class="form-control {% if errors and errors.get('current_password') %}is-invalid{% endif %}"
+            required>
+          <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
+            onclick="togglePwd('current_password', this)">👁</button>
+        </div>
+        {% if errors and errors.get('current_password') %}
+          <div class="invalid-feedback d-block">{{ errors.get('current_password') }}</div>
+        {% endif %}
+      </div>
+
+      <div class="mb-3">
+        <label for="new_password" class="form-label">新しいパスワード</label>
+        <div class="input-group">
+          <input type="password"
+            id="new_password"
+            name="new_password"
+            class="form-control {% if errors and errors.get('new_password') %}is-invalid{% endif %}"
+            required>
+          <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
+            onclick="togglePwd('new_password', this)">👁</button>
+        </div>
+        {% if errors and errors.get('new_password') %}
+          <div class="invalid-feedback d-block">{{ errors.get('new_password') }}</div>
+        {% endif %}
+      </div>
+
+      <div class="mb-3">
+        <label for="confirm_password" class="form-label">新しいパスワード（確認）</label>
+        <div class="input-group">
+          <input type="password"
+            id="confirm_password"
+            name="confirm_password"
+            class="form-control {% if errors and errors.get('confirm_password') %}is-invalid{% endif %}"
+            required>
+          <button type="button" class="btn btn-outline-secondary" aria-label="パスワード表示切り替え"
+            onclick="togglePwd('confirm_password', this)">👁</button>
+        </div>
+        {% if errors and errors.get('confirm_password') %}
+          <div class="invalid-feedback d-block">{{ errors.get('confirm_password') }}</div>
+        {% endif %}
+      </div>
+
+      <div class="d-grid gap-2">
+        <button type="submit" class="btn btn-primary">変更する</button>
+        <a href="{{ url_for('index') }}" class="btn btn-outline-secondary">戻る</a>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+function togglePwd(id, btn) {
+  const field = document.getElementById(id);
+  if (field.type === "password") {
+    field.type = "text";
+    btn.innerText = "🙈";
+  } else {
+    field.type = "password";
+    btn.innerText = "👁";
+  }
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create My Page template with password change form
- integrate password change route as `/my`
- update navigation link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bba415600832aad4df4cc5818159d