### PR TITLE
アップデート機能改良

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -38,6 +38,7 @@
         {% if session.get('is_superadmin') %}
         <li class="nav-item"><a class="nav-link" href="{{ url_for('mail_settings') }}">メール設定</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('view_audit_log') }}">監査ログ</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('update_system') }}">アップデート</a></li>
         {% endif %}
         {% endif %}
         {% if session.get('user_id') %}

--- a/templates/update.html
+++ b/templates/update.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block title %}アップデート{% endblock %}
+{% block content %}
+<h1 class="mb-3">アップデート</h1>
+{% if error %}
+<div class="alert alert-danger">{{ error }}</div>
+{% else %}
+<p>現在のコミット: <code>{{ local_commit }}</code></p>
+{% if remote_commit %}
+<p>最新のコミット: <code>{{ remote_commit }}</code></p>
+{% if update_available %}
+{% if critical_changes %}
+<div class="alert alert-danger">データベースや設定ファイルが変更されています。自動アップデートはできません。</div>
+{% else %}
+<div class="alert alert-warning">更新があります。</div>
+<form method="POST">
+  <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+  <button type="submit" class="btn btn-primary">アップデート実行</button>
+</form>
+{% endif %}
+{% if changed_files %}
+<details class="mt-3"><summary>変更ファイル一覧</summary>
+<ul>
+{% for f in changed_files %}
+  <li>{{ f }}</li>
+{% endfor %}
+</ul>
+</details>
+{% endif %}
+{% else %}
+<div class="alert alert-success">最新版です。</div>
+{% endif %}
+{% endif %}
+{% if message %}
+<pre class="mt-3">{{ message }}</pre>
+{% endif %}
+{% endif %}
+{% endblock %}
+


### PR DESCRIPTION
## 概要
- 更新確認時にリモートとの差分ファイルを取得する `get_changed_files` を追加
- 更新に DB スキーマや `.env.example` が含まれる場合は自動更新を抑止
- 変更ファイル一覧をテンプレートに表示

## テスト結果
- `pytest -q` を実行し16件成功

------
https://chatgpt.com/codex/tasks/task_e_684bc931989c832aabef612007750f44