### PR TITLE
Add indexes and improve DB init

### DIFF
--- a/app.py
+++ b/app.py
@@ -203,13 +203,13 @@ def handle_file_too_large(e):
 
 # === 7. DB初期化 ===
 def initialize_database():
-    if not os.path.exists(DB_PATH):
-        os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
-        conn = sqlite3.connect(DB_PATH)
-        with open(os.path.join(os.path.dirname(__file__), 'database', 'schema.sql'), encoding='utf-8') as f:
-            conn.executescript(f.read())
-        conn.commit()
-        conn.close()
+    """テーブルとインデックスを確実に作成する"""
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    with open(os.path.join(os.path.dirname(__file__), 'database', 'schema.sql'), encoding='utf-8') as f:
+        conn.executescript(f.read())
+    conn.commit()
+    conn.close()
 initialize_database()
 
 # === 8. 各種ユーティリティ ===

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -52,3 +52,15 @@ CREATE TABLE IF NOT EXISTS messages (
     FOREIGN KEY(sender_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY(recipient_id) REFERENCES users(id) ON DELETE CASCADE
 );
+
+-- 追加インデックス
+CREATE INDEX IF NOT EXISTS idx_attendance_user_timestamp
+    ON attendance(user_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_admin_managed_users_admin_id
+    ON admin_managed_users(admin_id);
+CREATE INDEX IF NOT EXISTS idx_admin_managed_users_user_id
+    ON admin_managed_users(user_id);
+CREATE INDEX IF NOT EXISTS idx_messages_recipient_read
+    ON messages(recipient_id, is_read);
+CREATE INDEX IF NOT EXISTS idx_messages_pair_timestamp
+    ON messages(sender_id, recipient_id, timestamp);


### PR DESCRIPTION
## Summary
- add indexes to reduce heavy queries
- always run schema on startup so indexes exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4938dcb4832a8b13d5fb4ae18014