### PR TITLE
Fix SSE worker timeouts

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ import smtplib
 from email.message import EmailMessage
 import subprocess
 import json
-from queue import Queue
+from queue import Queue, Empty
 
 load_dotenv()
 
@@ -967,8 +967,11 @@ def sse_events():
         push_unread(user_id)
         try:
             while True:
-                data = q.get()
-                yield f"data: {json.dumps(data)}\n\n"
+                try:
+                    data = q.get(timeout=15)
+                    yield f"data: {json.dumps(data)}\n\n"
+                except Empty:
+                    yield ": keep-alive\n\n"
         finally:
             user_streams[user_id].remove(q)
 


### PR DESCRIPTION
## Summary
- add `Empty` import from `queue`
- add keep-alive yields in SSE stream to avoid Gunicorn timeouts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eaa94ba70832aa331c7ef86084ebc