### PR TITLE
Fix overtime calculation with late start times

### DIFF
--- a/tests/test_overtime.py
+++ b/tests/test_overtime.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from app import calculate_overtime
+
+
+def test_overtime_with_late_start():
+    assert calculate_overtime("22:00", "18:00", "19:00") == "03:00"
+
+
+def test_overtime_standard():
+    assert calculate_overtime("20:30", "18:00", "09:00") == "02:30"
+
+
+def test_overtime_before_threshold():
+    assert calculate_overtime("17:30", "18:00", "09:00") == ""


### PR DESCRIPTION
## Summary
- consider start time when computing overtime
- adjust CSV export and log view to use new parameter
- add regression tests for overtime calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685811ab9e10832ab9810184489a333a