### PR TITLE
Chromeの読み込みハング修正

### DIFF
--- a/static/sw.js
+++ b/static/sw.js
@@ -12,6 +12,11 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (event.request.headers.get('accept') === 'text/event-stream' || url.pathname === '/events') {
+    // SSEはキャッシュせずに直接取得
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then(response => response || fetch(event.request))
   );


### PR DESCRIPTION
## Summary
- Service Worker で `/events`(SSE) をキャッシュ対象から除外

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858128e5abc832a981ef1796999e982