### PR TITLE
Add filename sanitization for CSV exports

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,8 @@ import json
 import time
 from utils import (
     is_valid_email, is_valid_time, get_client_info,
-    safe_fromisoformat, normalize_time_str, calculate_overtime
+    safe_fromisoformat, normalize_time_str, calculate_overtime,
+    sanitize_filename,
 )
 try:
     from gevent.queue import Queue, Empty
@@ -407,7 +408,8 @@ def generate_csv(user_id, name, year, month, target_dir, overtime_threshold='18:
         elif typ == 'out':
             daily_data[day]['out'] = time
             daily_data[day]['description'] = desc or ''
-    filename = f"{name}_{year}_{month:02d}_勤怠記録.csv"
+    safe_name = sanitize_filename(name)
+    filename = f"{safe_name}_{year}_{month:02d}_勤怠記録.csv"
     filepath = os.path.join(target_dir, filename)
     with open(filepath, 'w', newline='', encoding='utf-8-sig') as f:
         writer = csv.writer(f)

--- a/tests/test_export_security.py
+++ b/tests/test_export_security.py
@@ -37,3 +37,22 @@ def client(tmp_path):
 def test_path_traversal_rejected(client):
     resp = client.get('/exports/../app.py')
     assert resp.status_code == 400
+
+
+@pytest.mark.parametrize("name", ["../bad", "user/evil"])
+def test_generate_csv_name_sanitization(client, tmp_path, name):
+    export_dir = tmp_path / "exports"
+    export_dir.mkdir()
+    conn = sqlite3.connect(app_module.DB_PATH)
+    conn.execute(
+        "INSERT INTO attendance (user_id, timestamp, type) VALUES (1, '2023-01-01T09:00:00', 'in')"
+    )
+    conn.execute(
+        "INSERT INTO attendance (user_id, timestamp, type) VALUES (1, '2023-01-01T18:00:00', 'out')"
+    )
+    conn.commit()
+    conn.close()
+    with app.app_context():
+        path = app_module.generate_csv(1, name, 2023, 1, str(export_dir))
+    assert os.path.commonpath([str(export_dir), path]) == str(export_dir)
+    assert os.path.isfile(path)

--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,7 @@ __all__ = [
     'safe_fromisoformat',
     'normalize_time_str',
     'calculate_overtime',
+    'sanitize_filename',
 ]
 
 def is_valid_email(email: str) -> bool:
@@ -84,4 +85,9 @@ def calculate_overtime(out_time: str, threshold: str = '18:00') -> str:
     except ValueError:
         return ''
     return ''
+
+
+def sanitize_filename(name: str) -> str:
+    """Return a filename-safe string made of alphanumerics, hyphen and underscore."""
+    return re.sub(r'[^A-Za-z0-9_-]+', '', name)
 


### PR DESCRIPTION
## Summary
- prevent path traversal by sanitizing user names when generating CSV
- test that CSV filenames with malicious user names stay inside export dir

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e377a01f4832aa68832bf33ccb66e