### PR TITLE
Use compare_digest for CSRF token

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,7 +153,8 @@ app.jinja_env.globals['csrf_token'] = generate_csrf_token
 def check_csrf():
     if request.method == 'POST':
         token = request.form.get('_csrf_token')
-        if not token or session.get('_csrf_token') != token:
+        session_token = session.get('_csrf_token')
+        if not token or not session_token or not secrets.compare_digest(session_token, token):
             flash("セッションエラーが発生しました。やり直してください。", "danger")
             return False
     return True

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from flask import session
+from app import app, check_csrf
+
+
+def test_csrf_valid_token():
+    with app.test_request_context('/', method='POST', data={'_csrf_token': 'token'}):
+        session['_csrf_token'] = 'token'
+        assert check_csrf()
+
+
+def test_csrf_invalid_token():
+    with app.test_request_context('/', method='POST', data={'_csrf_token': 'bad'}):
+        session['_csrf_token'] = 'token'
+        assert not check_csrf()


### PR DESCRIPTION
## Summary
- use `secrets.compare_digest` in `check_csrf`
- test CSRF token handling

## Testing
- `python3 -m venv venv`
- `source venv/bin/activate`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e377cc124832a99f6b9a1aba75985