### PR TITLE
Remove auto clearing audit log and add CLI command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,5 @@ MAX_CONTENT_LENGTH=10485760
 # ログイン状態を保持する日数
 SESSION_LIFETIME_DAYS=7
 # 監査ログの保存場所
-# 監査ログはサービス起動時にリセット
+# 不要になったら `python app.py --clear-audit-log` で削除
 AUDIT_LOG_PATH=logs/audit.log

--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ kintai-system/
 | `SESSION_LIFETIME_DAYS` | ログインを保持する日数 |
 | `AUDIT_LOG_PATH` | 監査ログの保存先 |
 
+### 監査ログの管理
+監査ログはサービス起動時に自動で削除されません。不要になった場合は
+次のコマンドで手動クリアしてください。
+
+```bash
+python app.py --clear-audit-log
+```
+定期的なローテーションには `logrotate` などのツールをご利用ください。
+
 ---
 
 ## 本番運用例 (gunicorn + systemd)

--- a/app.py
+++ b/app.py
@@ -106,11 +106,11 @@ AUDIT_LOG_PATH = os.environ.get(
 os.makedirs(os.path.dirname(AUDIT_LOG_PATH), exist_ok=True)
 
 def clear_audit_log():
-    """サービス起動時に監査ログを空にする"""
+    """監査ログを空にするユーティリティ"""
     with open(AUDIT_LOG_PATH, 'w', encoding='utf-8'):
         pass
 
-clear_audit_log()
+# サービス起動時の自動クリアは廃止
 
 # === 1. 共通DBコネクション関数 ===
 def get_db():
@@ -1449,7 +1449,19 @@ def setup():
     return render_template('setup.html')
 
 if __name__ == '__main__':
-    debug_env = os.environ.get('FLASK_DEBUG', '0')
-    debug_mode = str(debug_env).lower() in ('1', 'true', 'yes')
-    # 開発サーバーでもSSEを扱えるようスレッドモードを有効化
-    app.run(host='0.0.0.0', port=8000, debug=debug_mode, threaded=True)
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Kintai System')
+    parser.add_argument(
+        '--clear-audit-log', action='store_true',
+        help='監査ログをクリアして終了')
+    args = parser.parse_args()
+
+    if args.clear_audit_log:
+        clear_audit_log()
+        print('Audit log cleared.')
+    else:
+        debug_env = os.environ.get('FLASK_DEBUG', '0')
+        debug_mode = str(debug_env).lower() in ('1', 'true', 'yes')
+        # 開発サーバーでもSSEを扱えるようスレッドモードを有効化
+        app.run(host='0.0.0.0', port=8000, debug=debug_mode, threaded=True)


### PR DESCRIPTION
## Summary
- avoid clearing audit log on startup
- add `--clear-audit-log` command
- document manual log clearing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e377ecf88832aa1d5461b7840fee7